### PR TITLE
Use lookup table for hashing to boost perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = 'README.md'
 
 [dependencies]
 error-chain = "^0.12.0"
+lazy_static = "1.1.0"
 
 [dev-dependencies]
 criterion = "^0.2"


### PR DESCRIPTION
Inspired by [this comment](https://github.com/onecodex/finch-rs/issues/26#issuecomment-421188321). It's kind of gross and doesn't `panic!` on a non-ACGTN nucleotide, but it does give a fairly substantial speed-up. 

Two notes:
 - I enabled by default; maybe we don't want to do that without a `panic!`/non-nucleotide check?
 - It'd be really nice to build the table with a `const fn`; I'm not sure what the current status of those is though.


Also, I really love the `bench` library you're using here:
```
nthash/nthash_iterator  time:   [47.482 us 47.956 us 48.578 us]
                        change: [-80.065% -79.659% -79.244%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
nthash/nthash_simple    time:   [167.02 us 167.98 us 169.18 us]
                        change: [-78.542% -78.384% -78.224%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
```