### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nthash"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "ntHash is a rolling hash function for hashing all possible k-mers in a DNA sequence."
 repository = "https://github.com/luizirber/nthash"
@@ -9,6 +9,7 @@ keywords = ["bioinformatics"]
 categories = ["science", "algorithms"]
 license = "MIT/Apache-2.0"
 readme = 'README.md'
+edition = "2018"
 
 [dependencies]
 error-chain = "^0.12.0"

--- a/benches/nthash.rs
+++ b/benches/nthash.rs
@@ -1,11 +1,10 @@
 #[macro_use]
 extern crate criterion;
-extern crate nthash;
-extern crate rand;
 
 use criterion::{Bencher, Criterion, Fun};
-use nthash::{nthash, NtHashIterator};
 use rand::distributions::{Distribution, Uniform};
+
+use nthash::{nthash, NtHashIterator};
 
 fn nthash_bench(c: &mut Criterion) {
     let range = Uniform::from(0..4);

--- a/benches/nthash.rs
+++ b/benches/nthash.rs
@@ -17,7 +17,8 @@ fn nthash_bench(c: &mut Criterion) {
             2 => 'G',
             3 => 'T',
             _ => 'N',
-        }).collect::<String>();
+        })
+        .collect::<String>();
 
     let nthash_it = Fun::new("nthash_iterator", |b: &mut Bencher, i: &String| {
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@ extern crate lazy_static;
 
 pub mod result;
 
-use result::{ErrorKind, Result};
+use crate::result::{ErrorKind, Result};
 
 pub(crate) const MAXIMUM_K_SIZE: usize = u32::max_value() as usize;
 
@@ -214,3 +214,5 @@ impl<'a> Iterator for NtHashIterator<'a> {
         (self.max_idx, Some(self.max_idx))
     }
 }
+
+impl<'a> ExactSizeIterator for NtHashIterator<'a> {}

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use super::MAXIMUM_K_SIZE;
 
-error_chain!{
+error_chain! {
     errors {
         KSizeOutOfRange(ksize: usize, seq_size: usize) {
             description("K size is out of range for the give sequence")

--- a/tests/nthash.rs
+++ b/tests/nthash.rs
@@ -1,7 +1,5 @@
-extern crate nthash;
 #[macro_use]
 extern crate quickcheck;
-extern crate rand;
 
 use quickcheck::{Arbitrary, Gen};
 use rand::Rng;


### PR DESCRIPTION
... and also declare the `ExactSizeIterator` trait (we already had `size_hint`, the required method)