### PR TITLE
Initialize with const fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = 'README.md'
 
 [dependencies]
 error-chain = "^0.12.0"
-lazy_static = "1.1.0"
 
 [dev-dependencies]
 criterion = "^0.2"

--- a/benches/nthash.rs
+++ b/benches/nthash.rs
@@ -17,7 +17,8 @@ fn nthash_bench(c: &mut Criterion) {
             2 => 'G',
             3 => 'T',
             _ => 'N',
-        }).collect::<String>();
+        })
+        .collect::<String>();
 
     let nthash_it = Fun::new("nthash_iterator", |b: &mut Bencher, i: &String| {
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,10 +10,10 @@
 //! This crate is based on ntHash [1.0.4](https://github.com/bcgsc/ntHash/releases/tag/v1.0.4).
 //!
 
+#![feature(min_const_fn)]
+
 #[macro_use]
 extern crate error_chain;
-#[macro_use]
-extern crate lazy_static;
 
 pub mod result;
 
@@ -21,28 +21,28 @@ use result::{ErrorKind, Result};
 
 pub(crate) const MAXIMUM_K_SIZE: usize = u32::max_value() as usize;
 
-// Note: Replace this with a const fn when it's available in stable
-// https://github.com/rust-lang/rust/issues/24111
-lazy_static! {
-    static ref H_LOOKUP: [u64; 256] = {
-        let mut lookup = [1; 256];
-        lookup[b'A' as usize] = 0x3c8b_fbb3_95c6_0474;
-        lookup[b'C' as usize] = 0x3193_c185_62a0_2b4c;
-        lookup[b'G' as usize] = 0x2032_3ed0_8257_2324;
-        lookup[b'T' as usize] = 0x2955_49f5_4be2_4456;
-        lookup[b'N' as usize] = 0;
-        lookup
-    };
-    static ref RC_LOOKUP: [u64; 256] = {
-        let mut lookup = [1; 256];
-        lookup[b'A' as usize] = 0x2955_49f5_4be2_4456;
-        lookup[b'C' as usize] = 0x2032_3ed0_8257_2324;
-        lookup[b'G' as usize] = 0x3193_c185_62a0_2b4c;
-        lookup[b'T' as usize] = 0x3c8b_fbb3_95c6_0474;
-        lookup[b'N' as usize] = 0;
-        lookup
-    };
+const fn h_lookup_table() -> [u64; 256] {
+    let mut lookup = [1; 256];
+    lookup[b'A' as usize] = 0x3c8b_fbb3_95c6_0474;
+    lookup[b'C' as usize] = 0x3193_c185_62a0_2b4c;
+    lookup[b'G' as usize] = 0x2032_3ed0_8257_2324;
+    lookup[b'T' as usize] = 0x2955_49f5_4be2_4456;
+    lookup[b'N' as usize] = 0;
+    lookup
 }
+
+const fn rc_lookup_table() -> [u64; 256] {
+    let mut lookup = [1; 256];
+    lookup[b'A' as usize] = 0x2955_49f5_4be2_4456;
+    lookup[b'C' as usize] = 0x2032_3ed0_8257_2324;
+    lookup[b'G' as usize] = 0x3193_c185_62a0_2b4c;
+    lookup[b'T' as usize] = 0x3c8b_fbb3_95c6_0474;
+    lookup[b'N' as usize] = 0;
+    lookup
+}
+
+const H_LOOKUP: [u64; 256] = h_lookup_table();
+const RC_LOOKUP: [u64; 256] = rc_lookup_table();
 
 #[inline(always)]
 fn h(c: u8) -> u64 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,6 @@
 //! This crate is based on ntHash [1.0.4](https://github.com/bcgsc/ntHash/releases/tag/v1.0.4).
 //!
 
-#![feature(min_const_fn)]
-
 #[macro_use]
 extern crate error_chain;
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,6 @@
 use super::MAXIMUM_K_SIZE;
 
-error_chain!{
+error_chain! {
     errors {
         KSizeOutOfRange(ksize: usize, seq_size: usize) {
             description("K size is out of range for the give sequence")


### PR DESCRIPTION
With Rust 1.33 we can use `const fn` and avoid `lazy_static` (as pointed in https://github.com/luizirber/nthash/pull/2#issuecomment-456617704 )