### PR TITLE
Print the illegal nucleotide when panicking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nthash"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Luiz Irber <luiz.irber@gmail.com>"]
 description = "ntHash is a rolling hash function for hashing all possible k-mers in a DNA sequence."
 repository = "https://github.com/luizirber/nthash"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ const RC_LOOKUP: [u64; 256] = {
 fn h(c: u8) -> u64 {
     let val = H_LOOKUP[c as usize];
     if val == 1 {
-        panic!("Non-ACGTN nucleotide encountered!")
+        panic!("Non-ACGTN nucleotide encountered! {}", c as char)
     }
     val
 }
@@ -49,7 +49,7 @@ fn h(c: u8) -> u64 {
 fn rc(nt: u8) -> u64 {
     let val = RC_LOOKUP[nt as usize];
     if val == 1 {
-        panic!("Non-ACGTN nucleotide encountered!")
+        panic!("Non-ACGTN nucleotide encountered! {}", nt as char)
     }
     val
 }

--- a/tests/nthash.rs
+++ b/tests/nthash.rs
@@ -57,11 +57,20 @@ fn iter_cmp() {
     }
 }
 
+#[should_panic(expected = "Non-ACGTN nucleotide encountered! E")]
+#[test]
+fn panic_non_acgtn() {
+    let ksize: usize = 2;
+    let sequences = "TGCAGNE";
+    let iter = NtHashIterator::new(sequences.as_bytes(), ksize).unwrap();
+    let _: Vec<u64> = iter.collect();
+}
+
 #[test]
 fn out_of_range_ksize_wont_panic() {
     let ksize: usize = 10;
     let sequences = "TGCAG";
-    let err = NtHashIterator::new(&sequences.as_bytes(), ksize).unwrap_err();
+    let err = NtHashIterator::new(sequences.as_bytes(), ksize).unwrap_err();
     assert_eq!(
         err.to_string(),
         "K size 10 is out of range for the given sequence size 5"
@@ -75,7 +84,7 @@ fn big_ksize_wont_panic() {
     let ksize: usize = (u64::from(u32::max_value()) + 1) as usize;
     let repetitions: usize = ((f64::from(u32::max_value()) + 1.0) / 5.0).ceil() as usize;
     let sequences = "TGCAG".repeat(repetitions);
-    let err = NtHashIterator::new(&sequences.as_bytes(), ksize).unwrap_err();
+    let err = NtHashIterator::new(sequences.as_bytes(), ksize).unwrap_err();
     assert_eq!(
         err.to_string(),
         "K size 4294967296 cannot exceed the size of a u32 4294967295"


### PR DESCRIPTION
Fixes #10